### PR TITLE
Modify Fn to FnMut

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -96,7 +96,8 @@ pub fn iter_variants_derive(input: pm::TokenStream) -> pm::TokenStream {
             #where_clause
         {
             type IterVariantsInput = Self;
-            fn iter_variants<F: Fn(Self::IterVariantsInput)>(f: F) {
+            #[allow(unused_mut)]
+            fn iter_variants<F: FnMut(Self::IterVariantsInput)>(mut f: F) {
                 #output
             }
         }


### PR DESCRIPTION
This is a potential breaking change.

If the user has implemented this trait for other types before, it may not compile properly.
It is recommended to move on to the next semver compatibility range before publising,
such as `0.1.4` -> `0.2.0`
